### PR TITLE
Añadir ejemplos para rutas anidadas

### DIFF
--- a/readme-es.md
+++ b/readme-es.md
@@ -158,6 +158,25 @@ En este ejemplo:
 •	La carpeta del componente usará el formato PascalCase.
 •	No se generarán los archivos .stories ni .test.
 
+### 🔧 Ejemplos para Rutas Anidadas
+- **Estructura de Carpetas Anidadas**: Usa rutas de carpetas como `src/pages/home/user` para crear rutas anidadas.
+  - Comando: `npx compilot-cli`
+  - Tipo: `page`
+  - Nombre: `user`
+  - Carpeta: `src/pages/home/user`
+  - Resultado: Genera `src/pages/home/user/UserPage.jsx` con ruta añadida a `src/app/Router.tsx`.
+- **Múltiples Niveles Anidados**: Para `src/pages/admin/dashboard/settings`, repite el proceso.
+  - Nombre: `settings`
+  - Carpeta: `src/pages/admin/dashboard/settings`
+- **Ejemplo de Ruta Personalizada**: Añade un comentario en `Router.tsx` como:
+```jsx
+//-- plop hook for import --//
+{/*-- plop hook for route --*/}
+<Route path="/admin/*" element={<AdminLayout />}>
+  {/*-- plop hook for nested route --*/}
+</Route>
+```
+
 #### 🧪 Cómo funciona la Metodología “Atomic”
 
 Si está activada, los componentes se agrupan en atoms, molecules y organisms:

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,25 @@ In this example:
 - The component folder in pascalCase
 - Disable .stories and .test generated files
 
+#### 🧪 Examples for Nested Routes
+- **Nested Folder Structure**: Use folder paths like `src/pages/home/user` to create nested routes.
+  - Command: `npx compilot-cli`
+  - Type: `page`
+  - Name: `user`
+  - Folder: `src/pages/home/user`
+  - Result: Generates `src/pages/home/user/UserPage.jsx` with route added to `src/app/Router.tsx`.
+- **Multiple Nested Levels**: For `src/pages/admin/dashboard/settings`, repeat the process.
+  - Name: `settings`
+  - Folder: `src/pages/admin/dashboard/settings`
+- **Custom Route Example**: Add a comment in `Router.tsx` like:
+  ```jsx
+  //-- plop hook for import --//
+  {/*-- plop hook for route --*/}
+  <Route path="/admin/*" element={<AdminLayout />}>
+    {/*-- plop hook for nested route --*/}
+  </Route>
+```
+
 #### 🧪 How the “Atomic” Methodology Works
 
 When the "atomic" methodology is enabled, the generated files will be organized into folders based on their atomic design category (e.g., `atoms`, `molecules`, `organisms`). For example:


### PR DESCRIPTION
Añadí ejemplos prácticos para rutas anidadas en la documentación, se van añadiendo al **Router.tsx**.